### PR TITLE
remove duplicate SKIPPED text

### DIFF
--- a/gitlint/linters.py
+++ b/gitlint/linters.py
@@ -186,7 +186,7 @@ def lint(filename, lines, config):
     else:
         return {
             filename: {
-                'skipped': ['SKIPPED: no linter is defined or enabled for files'
+                'skipped': ['no linter is defined or enabled for files'
                             ' with extension "%s"' % ext]
             }
         }


### PR DESCRIPTION
Currently, the output for skipped files looks like:

```
$ git commit...
Linting file: foo
SKIPPED: SKIPPED: no linter is defined or enabled for files with extension ""
```

where the first SKIPPED is in yellow.

This PR changes it to `SKIPPED: no linter is defined or enabled for files with extension ""`, where SKIPPED is still in yellow.
