### PR TITLE
Fix how modified lines are computed for files modified twice.

### DIFF
--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -120,7 +120,7 @@ def modified_lines(filename, extra_data, commit=None):
     """
     if extra_data is None:
         return []
-    if extra_data not in ('M ', ' M'):
+    if extra_data not in ('M ', ' M', 'MM'):
         return None
 
     if commit is None:

--- a/test/unittest/test_git.py
+++ b/test/unittest/test_git.py
@@ -131,9 +131,12 @@ class GitTest(unittest.TestCase):
             self.assertEqual(
                 [2, 5],
                 list(git.modified_lines('/home/user/repo/foo/bar.txt', 'M ')))
+            self.assertEqual(
+                [2, 5],
+                list(git.modified_lines('/home/user/repo/foo/bar.txt', 'MM')))
             expected_calls = [mock.call(
                 ['git', 'blame', '--porcelain',
-                 '/home/user/repo/foo/bar.txt'])] * 2
+                 '/home/user/repo/foo/bar.txt'])] * 3
             self.assertEqual(expected_calls, check_output.call_args_list)
 
     def test_modified_lines_with_commit(self):
@@ -157,9 +160,15 @@ class GitTest(unittest.TestCase):
                     '/home/user/repo/foo/bar.txt',
                     'M ',
                     commit='0123456789abcdef31410123456789abcdef3141')))
+            self.assertEqual(
+                [2, 5],
+                list(git.modified_lines(
+                    '/home/user/repo/foo/bar.txt',
+                    'MM',
+                    commit='0123456789abcdef31410123456789abcdef3141')))
             expected_calls = [mock.call(
                 ['git', 'blame', '--porcelain',
-                 '/home/user/repo/foo/bar.txt'])] * 2
+                 '/home/user/repo/foo/bar.txt'])] * 3
             self.assertEqual(expected_calls, check_output.call_args_list)
 
     def test_modified_lines_new_addition(self):


### PR DESCRIPTION
The first fix for #54, was generating all the lines in those files.