### PR TITLE
pre-commit.git-lint.sh - Corrected diff-filter argument.

### DIFF
--- a/scripts/pre-commit.git-lint.sh
+++ b/scripts/pre-commit.git-lint.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # First part return the files being commited, excluding deleted files.
-git diff-index -z --cached HEAD --name-only --diff-filter="(A|C|M|R|T|U|X|B)" |
+git diff-index -z --cached HEAD --name-only --diff-filter=ACMRTUXB |
 xargs --null --no-run-if-empty git lint;
 
 if [ "$?" != "0" ]; then


### PR DESCRIPTION
The pre-commit hook did not work on my git installation, version 1.9.1.

Example usage of the option --diff-filter is shown here: http://stackoverflow.com/a/7484817/501017