### PR TITLE
Removed non-used exclude_lines from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,3 @@ omit =
     */site-packages/ordereddict.py
     */site-packages/nose/*
     */unittest2/*
-
-exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover

--- a/gitlint/configs/config.yaml
+++ b/gitlint/configs/config.yaml
@@ -200,7 +200,7 @@ tidy:
   - .html
   command: tidy-wrapper.sh
   requirements:
-  - tidy5
+  - tidy
   - remove_template.py
   - grep
   arguments:

--- a/scripts/custom_linters/tidy-wrapper.sh
+++ b/scripts/custom_linters/tidy-wrapper.sh
@@ -20,6 +20,6 @@ FILENAME=${ARGV[$ARGC]};
 unset ARGV[$ARGC];
 
 remove_template.py $FILENAME |
-tidy5 ${ARGV[@]} 2>&1 |
+tidy ${ARGV[@]} 2>&1 |
 egrep -v "Warning: (.* proprietary attribute \"(itemtype|itemid|itemscope|itemprop)\"|missing <!DOCTYPE> declaration|inserting implicit <body>|inserting missing 'title' element)$" |
 uniq


### PR DESCRIPTION
The value was set to the default and furthermore it was in the
wrong config section. It was in the [run] section, but now it
should be in the [report] one.