### PR TITLE
System to ignore sets of files

### DIFF
--- a/gitlint/configs/config.yaml
+++ b/gitlint/configs/config.yaml
@@ -17,6 +17,14 @@
 # braces, as in '{{}}' or '{{foo}}'. See the pylint configuration for an
 # example.
 
+# Ignored paths
+# You can use this system to ignore paths from the linting. This can be useful 
+# when a frame work automatically generates files that do not pass you linting.
+# Uncomment to activate. The file paths use glob syntax.
+
+#ignore:
+#  - */migrations/*.py
+
 # CSS
 # Sample output:
 # /home/skreft/opensource/git-lint/test/e2etest/data/csslint/error.css: line 3, col 2, Warning - Duplicate property 'width' found.

--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -82,8 +82,8 @@ def modified_files(root, tracked_only=False, commit=None):
         r'(?P<mode>%s) (?P<filename>.+)' % modes_str,
         groups=('filename', 'mode'))
 
-    return dict((os.path.join(root, _remove_filename_quotes(filename)), mode)
-                for filename, mode in modified_file_status)
+    return {os.path.join(root, _remove_filename_quotes(filename)): mode
+            for filename, mode in modified_file_status}
 
 
 def _modified_files_with_commit(root, commit):

--- a/gitlint/linters.py
+++ b/gitlint/linters.py
@@ -141,6 +141,11 @@ def parse_yaml_config(yaml_config, repo_home):
     }
 
     for name, data in yaml_config.items():
+
+        #Skip the ignore path settings
+        if name == "ignore":
+            continue
+
         command = _replace_variables([data['command']], variables)[0]
         requirements = _replace_variables(data.get('requirements', []),
                                           variables)


### PR DESCRIPTION
The config file now can optionally have an "ignore" section containing
file name patterns that the linter will ignore. The patterns follow glob
like syntax (using fnmatch under the hood).

An example of a configuration is below.

ignore:
  - "*/migrations/*"

This is useful when files are generated by a framework that will not pass
the linter and you wish to always ignore them.