### PR TITLE
Update Pre Commit Hook Script

### DIFF
--- a/scripts/pre-commit.git-lint.sh
+++ b/scripts/pre-commit.git-lint.sh
@@ -14,8 +14,13 @@
 # limitations under the License.
 
 # First part return the files being commited, excluding deleted files.
-git diff-index -z --cached HEAD --name-only --diff-filter=ACMRTUXB |
-xargs --null --no-run-if-empty git lint;
+DIFF=$(git diff-index -z --cached HEAD --name-only --diff-filter=ACMRTUXB)
+if [ -z "$DIFF" ]
+then
+  exit 0;
+else
+  git lint;
+fi
 
 if [ "$?" != "0" ]; then
   echo "There are some problems with the modified files.";

--- a/scripts/pre-commit.hg-lint.sh
+++ b/scripts/pre-commit.hg-lint.sh
@@ -18,8 +18,13 @@ if [ "$NO_VERIFY" != "" ]; then
     exit 0
 fi
 
-hg status --change $HG_NODE | cut -b 3- | tr '\n' '\0' |
-xargs --null --no-run-if-empty git-lint;
+DIFF=$(hg status --change $HG_NODE | cut -b 3- | tr '\n' '\0')
+if [ -z "$DIFF" ]
+then
+  exit 0;
+else
+  git lint;
+fi
 
 if [ "$?" != "0" ]; then
   echo "There are some problems with the modified files.";


### PR DESCRIPTION
This PR updates the pre-commit hook scripts:

 * `pre-commit.git-lint.sh`
 * `pre-commit.hg-lint.sh`

These changes are needed as the previous command to initialize `git lint` used `xargs` flags that were not available on OSX (namely `--null` and `--no-run-if-empty`). The updated scripts should perform the same functionality and will run on OSX.