### PR TITLE
Do not try to lint submodules

### DIFF
--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -218,6 +218,8 @@ def main(argv, stdout=sys.stdout, stderr=sys.stderr):
     json_result = {}
 
     for filename in sorted(modified_files.keys()):
+        if os.path.isdir(filename):
+            continue
         rel_filename = os.path.relpath(filename)
         if not json_output:
             stdout.write('Linting file: %s%s' %


### PR DESCRIPTION
Submodules are marked as changed by `git diff-index` and AFAIK there is
not way to filter them out via `--diff-filter` argument