### PR TITLE
Check for shellbang if file has no extension

### DIFF
--- a/gitlint/configs/config.yaml
+++ b/gitlint/configs/config.yaml
@@ -103,6 +103,8 @@ pylint:
 pep8:
   extensions:
   - .py
+  shellbang:
+  - /usr/bin/env python
   command: pep8
   arguments:
   - "--max-line-length=80"

--- a/gitlint/linters.py
+++ b/gitlint/linters.py
@@ -133,7 +133,8 @@ def _replace_variables(data, variables):
 # TODO(skreft): validate data['filter'], ie check that only has valid fields.
 def parse_yaml_config(yaml_config, repo_home):
     """Converts a dictionary (parsed Yaml) to the internal representation."""
-    config = collections.defaultdict(list)
+    config = {'extensions': collections.defaultdict(list),
+              'shellbangs': collections.defaultdict(list)}
 
     variables = {
         'DEFAULT_CONFIGS': os.path.join(os.path.dirname(__file__),
@@ -161,11 +162,11 @@ def parse_yaml_config(yaml_config, repo_home):
                                      arguments,
                                      data['filter'])
         for extension in data['extensions']:
-            config[extension].append(linter_command)
+            config['extensions'][extension].append(linter_command)
 
         if 'shellbang' in data:
             for shellbang in data['shellbang']:
-                config[shellbang].append(linter_command)
+                config['shellbangs'][shellbang].append(linter_command)
 
     return config
 
@@ -186,12 +187,24 @@ def lint(filename, lines, config):
       'comments' will have the messages.
     """
     _, ext = os.path.splitext(filename)
-    if ext not in config:
+    linters = []
+    if 'extensions' in config and ext in config['extensions']:
+        linters = config['extensions'][ext]
+    elif 'shellbangs' in config:
         with open(filename, 'r') as f:
-            ext = f.readline()[2:].strip()
-    if ext in config:
+            first_line = f.readline()
+            if first_line and 'shellbangs' in config:
+                # 2x strip() to handle the following cases:
+                # - '#! /bin/sh'
+                # - ' #!/bin/sh'
+                # - ' #! /bin/sh'
+                shellbang = first_line.strip()[2:].strip()
+                if shellbang in config['shellbangs']:
+                    linters = config['shellbangs'][shellbang]
+
+    if linters:
         output = collections.defaultdict(list)
-        for linter in config[ext]:
+        for linter in linters:
             linter_output = linter(filename, lines)
             for category, values in linter_output[filename].items():
                 output[category].extend(values)
@@ -204,10 +217,9 @@ def lint(filename, lines, config):
         return {
             filename: dict(output)
         }
-    else:
-        return {
-            filename: {
-                'skipped': ['no linter is defined or enabled for files'
-                            ' with extension "%s"' % ext]
-            }
+    return {
+        filename: {
+            'skipped': ['no linter is defined or enabled for files'
+                        ' with extension "%s"' % ext]
         }
+    }

--- a/gitlint/linters.py
+++ b/gitlint/linters.py
@@ -163,6 +163,10 @@ def parse_yaml_config(yaml_config, repo_home):
         for extension in data['extensions']:
             config[extension].append(linter_command)
 
+        if 'shellbang' in data:
+            for shellbang in data['shellbang']:
+                config[shellbang].append(linter_command)
+
     return config
 
 
@@ -182,6 +186,9 @@ def lint(filename, lines, config):
       'comments' will have the messages.
     """
     _, ext = os.path.splitext(filename)
+    if ext not in config:
+        with open(filename, 'r') as f:
+            ext = f.readline()[2:].strip()
     if ext in config:
         output = collections.defaultdict(list)
         for linter in config[ext]:

--- a/test/e2etest/test_e2e.py
+++ b/test/e2etest/test_e2e.py
@@ -152,7 +152,8 @@ class E2EBase(object):
     @classmethod
     def add_linter_checks(cls):
         """Add a test for each defined linter and extension."""
-        for extension, linter_list in gitlint.get_config(None).items():
+        config = gitlint.get_config(None)
+        for extension, linter_list in config['extensions'].items():
             for linter in linter_list:
                 cls.add_linter_check(linter.args[0], extension)
 

--- a/test/unittest/test_gitlint.py
+++ b/test/unittest/test_gitlint.py
@@ -495,8 +495,8 @@ class GitLintTest(unittest.TestCase):
                        create=True) as mock_open:
             parsed_config = gitlint.get_config(self.root)
             mock_open.assert_called_once_with(git_config)
-            self.assertEqual(['.py'], list(parsed_config.keys()))
-            self.assertEqual(1, len(parsed_config['.py']))
+            self.assertEqual(['.py'], list(parsed_config['extensions'].keys()))
+            self.assertEqual(1, len(parsed_config['extensions']['.py']))
 
     def test_get_config_from_default(self):
         with mock.patch('os.path.exists', return_value=False):
@@ -516,7 +516,8 @@ class GitLintTest(unittest.TestCase):
                        mock.mock_open(read_data=''),
                        create=True) as mock_open:
             parsed_config = gitlint.get_config(self.root)
-            self.assertEqual({}, parsed_config)
+            self.assertEqual({}, parsed_config['extensions'])
+            self.assertEqual({}, parsed_config['shellbangs'])
 
     def test_format_comment(self):
         self.assertEqual('', gitlint.format_comment({}))


### PR DESCRIPTION
This commit allows specifieng the shellbang via `shellbang` key by
providing the executable line. The `shellbang` value should not contain
the actual shellbang (`#!`) to ease up YAML integration.