### PR TITLE
Fix cached results when program or args change

### DIFF
--- a/gitlint/configs/pylintrc
+++ b/gitlint/configs/pylintrc
@@ -180,7 +180,7 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=f,i,j,k,ex,Run,_
+good-names=f,i,j,k,ex,Run,_,_
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/gitlint/linters.py
+++ b/gitlint/linters.py
@@ -72,7 +72,7 @@ def lint_command(name, program, arguments, filter_regex, filename, lines):
 
     Returns: dict: a dict with the extracted info from the message.
     """
-    output = utils.get_output_from_cache(name, filename)
+    output = utils.get_output_from_cache(name, program, arguments, filename)
 
     if output is None:
         call_arguments = [program] + arguments + [filename]
@@ -90,7 +90,7 @@ def lint_command(name, program, arguments, filter_regex, filename, lines):
                 }
             }
         output = output.decode('utf-8')
-        utils.save_output_in_cache(name, filename, output)
+        utils.save_output_in_cache(name, program, arguments, filename, output)
 
     output_lines = output.split(os.linesep)
 

--- a/test/unittest/test_utils.py
+++ b/test/unittest/test_utils.py
@@ -113,6 +113,24 @@ class UtilsTest(unittest.TestCase):
             '/home/user/.git-lint/cache/466b0918b56b96a47446546e4cbe15019022666c',
             utils._get_cache_filename('linter3', 'lint3', {}, '/bar/file.txt'))
 
+    @mock.patch('os.path.abspath', side_effect=_mock_abspath)
+    @mock.patch('os.path.expanduser', side_effect=lambda a: '/home/user')
+    def test_cache_name_change(self, _, __):  # pylint: disable=invalid-name
+        """ Make sure file name changes when program name or arguments change
+        """
+        result1 = utils._get_cache_filename('linter', 'lint1', {}, 'file.txt')
+        result2 = utils._get_cache_filename('linter', 'lint2', {}, 'file.txt')
+        result3 = utils._get_cache_filename('linter', 'lint1', {
+            'args': [1, 2, 3]
+            }, 'file.txt')
+        result4 = utils._get_cache_filename('linter', 'lint2', {}, 'file.txt')
+
+        self.assertNotEqual(result1, result2)
+        self.assertNotEqual(result1, result3)
+        self.assertNotEqual(result2, result3)
+        self.assertEqual(result2, result4)
+
+
     def test_save_output_in_cache(self):
         output = 'Some content'
         cache_filename = '/cache/filename.txt'


### PR DESCRIPTION
When arguments in .gitlintrc change `git-lint` still serves the old cached
results. This commit changes it.