### PR TITLE
Fixes setup due to encoding issues in some systems.

### DIFF
--- a/scripts/install-linters.sh
+++ b/scripts/install-linters.sh
@@ -82,6 +82,6 @@ sudo make install
 cd -
 
 # PMD
-wget "http://downloads.sourceforge.net/project/pmd/pmd/5.1.3/pmd-bin-5.1.3.zip?r=&ts=`date +%s`&use_mirror=ufpr"
+wget --no-check-certificate "http://downloads.sourceforge.net/project/pmd/pmd/5.1.3/pmd-bin-5.1.3.zip?r=&ts=`date +%s`&use_mirror=ufpr"
 unzip -q pmd-bin-*
 mv pmd-bin-5.1.3 pmd-bin

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import ast
+import io
 import os
 from setuptools import setup, find_packages
 
@@ -26,7 +27,7 @@ setup(
     name='git-lint',
     version=version,
     description='Git Lint',
-    long_description=open('README.rst').read(),
+    long_description=io.open('README.rst', encoding='utf-8').read(),
     author='Sebastian Kreft',
     url='http://github.com/sk-/git-lint',
     packages=find_packages(exclude=['test']),


### PR DESCRIPTION
By default open will use a decoder that's platform dependent. See https://docs.python.org/3.6/library/functions.html#open

Instead we need to explicitly provide the file's encoding. For which we need to use the function from io, so that it can also be used in python 2.7.

Fixes #107.