### PR TITLE
`utilities.py:_open_for_write` no longer has a race condition

### DIFF
--- a/gitlint/utils.py
+++ b/gitlint/utils.py
@@ -17,6 +17,9 @@ import io
 import os
 import re
 
+# This can be just pathlib when 2.7 and 3.4 support is dropped.
+import pathlib2 as pathlib
+
 
 def filter_lines(lines, filter_regex, groups=None):
     """Filters out the lines not matching the pattern.
@@ -64,8 +67,7 @@ def programs_not_in_path(programs):
 def _open_for_write(filename):
     """Opens filename for writing, creating the directories if needed."""
     dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
+    pathlib.Path(dirname).mkdir(parents=True, exist_ok=True)
 
     return io.open(filename, 'w')
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'html-linter',
         'template-remover',
         'docutils',
+        'pathlib2',
     ],
     tests_require=['nose>=1.3', 'mock'],
     extras_require={

--- a/test/unittest/test_utils.py
+++ b/test/unittest/test_utils.py
@@ -69,26 +69,20 @@ class UtilsTest(unittest.TestCase):
                                     r'(?P<line>\d+): .*',
                                     groups=('line', 'debug'))))
 
-    def test_open_for_write_file_exists(self):
+    def test_open_for_write(self):
         filename = 'foo/bar/new_file'
         with mock.patch('io.open',
                         mock.mock_open(),
                         create=True) as mock_open, \
-             mock.patch('os.path.exists', return_value=True):
+             mock.patch.object(
+                utils.pathlib.Path,
+                'mkdir',
+                return_value=True) as mock_create:
             utils._open_for_write(filename)
 
-            mock_open.assert_called_once_with(filename, 'w')
-
-    def test_open_for_write_file_does_not_exist(self):
-        filename = 'foo/bar/new_file'
-        with mock.patch('io.open',
-                        mock.mock_open(),
-                        create=True) as mock_open, \
-             mock.patch('os.path.exists', return_value=False), \
-             mock.patch('os.makedirs') as mock_makedirs:
-            utils._open_for_write(filename)
-
-            mock_makedirs.assert_called_once_with(os.path.dirname(filename))
+            mock_create.assert_called_once_with(
+                parents=True,
+                exist_ok=True)
             mock_open.assert_called_once_with(filename, 'w')
 
     def test_get_cache_filename(self):


### PR DESCRIPTION
Fixes #117 

# Changes

* Added Pathlib2 dependency so that Python2 has the same interface
as Python3 for file system manipulation.
* Changed `_open_for_write` to use  `Path.mkdir` for cache file
creation to avoid race conditions.

# Testing
```
% nosetests test/unittest
nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module
................................................................................
----------------------------------------------------------------------
Ran 80 tests in 1.818s

OK
```

# NOTE
In a perfect would I would prove that there's no race condition using injected locks to stall the main process until the cache directory is created but I don't know how to do that with multiprocess.