### PR TITLE
Allow using various git diff options for comparisons

### DIFF
--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -35,7 +35,7 @@ Options:
     --json         Prints the result as a json string. Useful to use it in
                    conjunction with other tools.
     --last-commit  Checks the last checked-out commit. Equivalent to
-                   --diff HEAD^ This is mostly useful when used as:
+                   "--diff HEAD^" This is mostly useful when used as:
                    git checkout <revid>; git lint --last-commit.
     --diff=<diff>  Gets the difference between the current HEAD and the commit
                    or branch specified

--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long,E501
 """
 git-lint: improving source code one step at a time
 
@@ -40,7 +40,7 @@ Options:
                    compatible with --last-diff To get commits on the current
                    branch but not master; git lint --diff 'HEAD ^master'
 """
-# pylint: enable=line-too-long
+# pylint: enable=line-too-long,E501
 
 from __future__ import unicode_literals
 

--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -34,8 +34,8 @@ Options:
     -t --tracked   Lints only tracked files.
     --json         Prints the result as a json string. Useful to use it in
                    conjunction with other tools.
-    --last-commit  Checks the last checked-out commit. Equivalent to --diff HEAD^
-                   This is mostly useful when used as:
+    --last-commit  Checks the last checked-out commit. Equivalent to
+                   --diff HEAD^ This is mostly useful when used as:
                    git checkout <revid>; git lint --last-commit.
     --diff=<diff>  Gets the difference between the current HEAD and the commit
                    or branch specified

--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=line-too-long
 """
 git-lint: improving source code one step at a time
 
@@ -23,7 +24,7 @@ It supports many filetypes, including:
 
 Usage:
     git-lint [-f | --force] [--json] [--last-commit] [FILENAME ...]
-    git-lint [-t | --tracked] [-f | --force] [--json] [(--last-commit | --diff diff)]
+    git-lint [-t | --tracked] [-f | --force] [--json] [(--last-commit | --diff DIFF)]
     git-lint -h | --version
 
 Options:
@@ -39,6 +40,7 @@ Options:
                    compatible with --last-diff To get commits on the current
                    branch but not master; git lint --diff 'HEAD ^master'
 """
+# pylint: enable=line-too-long
 
 from __future__ import unicode_literals
 

--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# pylint: disable=line-too-long,E501
 """
 git-lint: improving source code one step at a time
 
@@ -24,7 +23,8 @@ It supports many filetypes, including:
 
 Usage:
     git-lint [-f | --force] [--json] [--last-commit] [FILENAME ...]
-    git-lint [-t | --tracked] [-f | --force] [--json] [(--last-commit | --diff DIFF)]
+    git-lint [-t | --tracked] [-f | --force] [--json]
+        [(--last-commit | --diff DIFF)]
     git-lint -h | --version
 
 Options:
@@ -40,7 +40,6 @@ Options:
                    compatible with --last-diff To get commits on the current
                    branch but not master; git lint --diff 'HEAD ^master'
 """
-# pylint: enable=line-too-long,E501
 
 from __future__ import unicode_literals
 

--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -55,7 +55,7 @@ def modified_files(root, tracked_only=False, target=None):
     assert os.path.isabs(root), "Root has to be absolute, got: %s" % root
 
     if target:
-        return _modified_files_with_diff_target(root, target)
+        return _modified_files_with_target(root, target)
 
     # Convert to unicode and split
     status_lines = subprocess.check_output([
@@ -77,7 +77,7 @@ def modified_files(root, tracked_only=False, target=None):
                 for filename, mode in modified_file_status)
 
 
-def _modified_files_with_diff_target(root, target):
+def _modified_files_with_target(root, target):
     # Convert to unicode and split
     status_lines = subprocess.check_output([
         'git', 'diff-tree', '-r', '--root', '--no-commit-id', '--name-status',

--- a/gitlint/hg.py
+++ b/gitlint/hg.py
@@ -42,7 +42,8 @@ def last_commit():
         return None
 
 
-def modified_files(root, tracked_only=False, commit=None):
+# pylint: disable=unused-argument
+def modified_files(root, tracked_only=False, commit=None, diff=None):
     """Returns a list of files that has been modified since the last commit.
 
     Args:
@@ -50,6 +51,7 @@ def modified_files(root, tracked_only=False, commit=None):
       tracked_only: exclude untracked files when True.
       commit: SHA1 of the commit. If None, it will get the modified files in the
         working copy.
+      diff: Unused.  Necessary for vcs compatibility
 
     Returns: a dictionary with the modified files as keys, and additional
       information as value. In this case it adds the status returned by
@@ -79,14 +81,17 @@ def modified_files(root, tracked_only=False, commit=None):
                 for filename, mode in modified_file_status)
 
 
-def modified_lines(filename, extra_data, commit=None):
+# pylint: enable=unused-argument
+
+
+def modified_lines(filename, extra_data, commits=None):
     """Returns the lines that have been modifed for this file.
 
     Args:
       filename: the file to check.
       extra_data: is the extra_data returned by modified_files. Additionally, a
         value of None means that the file was not modified.
-      commit: the complete sha1 (40 chars) of the commit. Note that specifying
+      commits: the complete sha1 (40 chars) of the commit. Note that specifying
         this value will only work (100%) when commit == last_commit (with
         respect to the currently checked out revision), otherwise, we could miss
         some lines.
@@ -100,8 +105,11 @@ def modified_lines(filename, extra_data, commit=None):
         return None
 
     command = ['hg', 'diff', '-U', '0']
-    if commit:
-        command.append('--change=%s' % commit)
+    if commits:
+        assert len(commits) == 1, \
+            "git-lint does not support multiple commits for mercurial yet"
+
+        command.append('--change=%s' % commits[0])
     command.append(filename)
 
     # Split as bytes, as the output may have some non unicode characters.

--- a/test/e2etest/test_e2e.py
+++ b/test/e2etest/test_e2e.py
@@ -97,20 +97,16 @@ class E2EMixin(object):
         """Get the common file names to be checked by the linter"""
         data_dirname = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), 'data')
-        filename_repo = os.path.join(
-            self.temp_directory, '%s%s' % (linter_name, extension))
+        filename_repo = os.path.join(self.temp_directory,
+                                     '%s%s' % (linter_name, extension))
         filename_original = os.path.join(data_dirname, linter_name,
                                          'original%s' % extension)
         filename_error = os.path.join(data_dirname, linter_name,
                                       'error%s' % extension)
         filename_nonewerror = os.path.join(data_dirname, linter_name,
                                            'nonewerror%s' % extension)
-        return (
-            filename_original,
-            filename_error,
-            filename_nonewerror,
-            filename_repo
-        )
+        return (filename_original, filename_error, filename_nonewerror,
+                filename_repo)
 
     # TODO(skreft): check that the first file has more than 1 error, check that
     # the second file has 1 new error, check also the lines that changed.
@@ -123,8 +119,7 @@ class E2EMixin(object):
         - <linter>/nonewerror.<extension>: A line was modified/added from the
           last file, but no new errors are introduced.
         """
-        filenames = self.get_filenames(
-            linter_name, extension)
+        filenames = self.get_filenames(linter_name, extension)
         filename_original = filenames[0]
         filename_error = filenames[1]
         filename_nonewerror = filenames[2]

--- a/test/unittest/test_gitlint.py
+++ b/test/unittest/test_gitlint.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 
+from docopt import DocoptExit
 import mock
 from pyfakefs import fake_filesystem_unittest
 
@@ -86,15 +87,15 @@ class GitLintTest(fake_filesystem_unittest.TestCase):
         self.git_modified_lines.reset_mock()
         self.lint.reset_mock()
 
-    def assert_mocked_calls(self, tracked_only=False, commit=None):
+    def assert_mocked_calls(self, tracked_only=False, commit=None, diff=None):
         """Checks if the mocks were called as expected.
 
         This method exists to avoid duplication.
         """
         self.git_modified_files.assert_called_once_with(
-            self.root, tracked_only=tracked_only, commit=commit)
+            self.root, tracked_only=tracked_only, commit=commit, diff=diff)
         self.git_modified_lines.assert_called_once_with(
-            self.filename, ' M', commit=commit)
+            self.filename, ' M', commits=[commit] if commit else None)
         self.lint.assert_called_once_with(self.filename, [3, 14], mock.ANY)
 
     def test_find_invalid_filenames(self):
@@ -129,11 +130,30 @@ class GitLintTest(fake_filesystem_unittest.TestCase):
             [], stdout=None, stderr=self.stderr))
         self.assertIn('Not a git repository', self.stderr.getvalue())
 
+    def test_main_diff_and_last_commit(self):
+        self.assertRaises(
+            DocoptExit,
+            gitlint.main, ['git-lint', '--diff', 'a ^b', '--last-commit'],
+            stdout=None,
+            stderr=self.stderr)
+
+    def test_main_diff_not_in_git_repo(self):
+        self.git_repository_root.return_value = None
+        self.hg_repository_root.return_value = self.root
+        self.assertEqual(
+            128,
+            gitlint.main(
+                ['git-lint', '--diff', 'a ^b'],
+                stdout=None,
+                stderr=self.stderr))
+        self.assertIn('fatal: --diff is only valid with git repositories',
+                      self.stderr.getvalue())
+
     def test_main_nothing_changed(self):
         self.git_modified_files.return_value = {}
         self.assertEqual(0, gitlint.main([], stdout=None, stderr=None))
         self.git_modified_files.assert_called_once_with(
-            self.root, tracked_only=False, commit=None)
+            self.root, tracked_only=False, commit=None, diff=None)
 
     def test_main_file_changed_and_still_valid(self):
         lint_response = {self.filename: {'comments': []}}
@@ -315,7 +335,7 @@ class GitLintTest(fake_filesystem_unittest.TestCase):
         self.assertIn('line 3: error', self.stdout.getvalue())
 
         self.git_modified_files.assert_called_once_with(
-            self.root, tracked_only=False, commit=None)
+            self.root, tracked_only=False, commit=None, diff=None)
         self.lint.assert_called_once_with(self.filename, None, mock.ANY)
 
         self.reset_mock_calls()
@@ -327,7 +347,7 @@ class GitLintTest(fake_filesystem_unittest.TestCase):
         self.assertIn('line 3: error', self.stdout.getvalue())
 
         self.git_modified_files.assert_called_once_with(
-            self.root, tracked_only=False, commit=None)
+            self.root, tracked_only=False, commit=None, diff=None)
         self.lint.assert_called_once_with(self.filename, None, mock.ANY)
 
     def test_main_with_invalid_files(self):
@@ -365,10 +385,10 @@ class GitLintTest(fake_filesystem_unittest.TestCase):
                 os.path.basename(self.filename2), self.stdout.getvalue())
 
             self.git_modified_files.assert_called_once_with(
-                self.root, tracked_only=False, commit=None)
+                self.root, tracked_only=False, commit=None, diff=None)
             expected_calls = [
-                mock.call(self.filename, ' M', commit=None),
-                mock.call(self.filename2, None, commit=None),
+                mock.call(self.filename, ' M', commits=None),
+                mock.call(self.filename2, None, commits=None),
             ]
             self.assertEqual(expected_calls,
                              self.git_modified_lines.call_args_list)
@@ -400,10 +420,10 @@ class GitLintTest(fake_filesystem_unittest.TestCase):
             self.assertEqual('', self.stderr.getvalue())
 
             self.git_modified_files.assert_called_once_with(
-                self.root, tracked_only=False, commit=None)
+                self.root, tracked_only=False, commit=None, diff=None)
             expected_calls = [
-                mock.call(self.filename, ' M', commit=None),
-                mock.call(self.filename2, None, commit=None)
+                mock.call(self.filename, ' M', commits=None),
+                mock.call(self.filename2, None, commits=None)
             ]
             self.assertEqual(expected_calls,
                              self.git_modified_lines.call_args_list)

--- a/test/unittest/test_hg.py
+++ b/test/unittest/test_hg.py
@@ -128,7 +128,7 @@ class HgTest(unittest.TestCase):
                              hg.modified_lines(
                                  '/home/user/repo/foo/bar.txt',
                                  'M',
-                                 commit=commit)))
+                                 commits=[commit])))
         check_output.assert_called_once_with([
             'hg', 'diff', '-U', '0',
             '--change=%s' % commit, '/home/user/repo/foo/bar.txt'

--- a/test/unittest/test_hg.py
+++ b/test/unittest/test_hg.py
@@ -81,7 +81,7 @@ class HgTest(unittest.TestCase):
             '/home/user/repo/docs/file1.txt': 'A',
             '/home/user/repo/data/file2.json': 'M',
             '/home/user/repo/untracked.txt': '?'
-        }, hg.modified_files('/home/user/repo', commit=commit))
+        }, hg.modified_files('/home/user/repo', target=commit))
         check_output.assert_called_once_with(
             ['hg', 'status', '--change=%s' % commit])
 
@@ -128,7 +128,7 @@ class HgTest(unittest.TestCase):
                              hg.modified_lines(
                                  '/home/user/repo/foo/bar.txt',
                                  'M',
-                                 commits=[commit])))
+                                 target=commit)))
         check_output.assert_called_once_with([
             'hg', 'diff', '-U', '0',
             '--change=%s' % commit, '/home/user/repo/foo/bar.txt'
@@ -149,12 +149,12 @@ class HgTest(unittest.TestCase):
                                                None)))
 
     @mock.patch('subprocess.check_output', return_value=b'0a' * 20 + b'\n')
-    def test_last_commit(self, check_output):
-        self.assertEqual('0a' * 20, hg.last_commit())
+    def test_diff_target(self, check_output):
+        self.assertEqual('0a' * 20, hg.diff_target())
         check_output.assert_called_once_with(
             ['hg', 'parent', '--template={node}'], stderr=subprocess.STDOUT)
 
     @mock.patch('subprocess.check_output')
-    def test_last_commit_not_in_repo(self, check_output):
+    def test_diff_target_not_in_repo(self, check_output):
         check_output.side_effect = subprocess.CalledProcessError(255, '', '')
-        self.assertEqual(None, hg.last_commit())
+        self.assertEqual(None, hg.diff_target())


### PR DESCRIPTION
Instead of having to do funky stuff with soft git resets, this allows the user
to pass a `--diff` option.  This option can be anything that works with both
`git diff-tree` and `git rev-list`.  This option does not work with mercurial
yet.  This is particularly helpful in CI pipelines that rely on PRs.
Effectively, you run `git lint --diff 'HEAD ^<target-branch>'`

The change basically works by looking at all the commits that are different
instead of just the `--last-commit`.  It uses the `git rev-list` command to
determine which commits are different.  It then uses the same `modified_lines`
function with a slight modification.  `modified lines` now uses a regex OR
condition for all of the commits instead of just one commit.