### PR TITLE
Silence yaml load warning

### DIFF
--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -104,7 +104,7 @@ def get_config(repo_root):
         if not content:
             yaml_config = {}
         else:
-            yaml_config = yaml.load(content)
+            yaml_config = yaml.safe_load(content)
 
     return linters.parse_yaml_config(yaml_config, repo_root)
 


### PR DESCRIPTION
```
/home/venv/lib/python3.6/site-packages/gitlint/__init__.py:105: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  yaml_config = yaml.load(content)
```

We could preserve existing behaviour with `yaml.full_load(content)` or
`yaml.load(content, Loader=yaml.FullLoader)` - that's up to the
maintainer. But it seems to me that safe_load is most appropriate
in this case.

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation